### PR TITLE
fix: add `/api` to route paths

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,4 +1,11 @@
+import { VersioningOptions, VersioningType } from '@nestjs/common';
+
 export enum SupportedChainId {
   GOERLI = '5',
   GNOSIS_CHAIN = '100',
 }
+
+export const API_VERSIONING: VersioningOptions = {
+  type: VersioningType.URI,
+  prefix: 'api/v',
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,10 +2,11 @@ import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 
 import { AppModule } from './app.module';
+import { API_VERSIONING } from './config/constants';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.enableVersioning();
+  app.enableVersioning(API_VERSIONING);
 
   const configService = app.get(ConfigService);
   const port = configService.get('applicationPort');

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -10,6 +10,7 @@ import configuration from '../../config/configuration';
 import { RelayService } from './relay.service';
 import { RelayLimitService } from './services/relay-limit.service';
 import { MOCK_EXEC_TX_CALL_DATA } from '../../mocks/transaction-data.mock';
+import { API_VERSIONING } from '../../config/constants';
 
 jest.mock('axios');
 
@@ -39,7 +40,7 @@ describe('RelayController', () => {
     relayLimitService = moduleFixture.get<RelayLimitService>(RelayLimitService);
 
     app = moduleFixture.createNestApplication();
-    app.enableVersioning();
+    app.enableVersioning(API_VERSIONING);
 
     await app.init();
   });
@@ -48,7 +49,7 @@ describe('RelayController', () => {
     await app.close();
   });
 
-  describe('/v1/relay (POST)', () => {
+  describe('/api/v1/relay (POST)', () => {
     it('should return a 201 when the body is valid', async () => {
       axios.default.get = jest.fn().mockResolvedValue({ data: 'mockSafe' });
 
@@ -63,7 +64,7 @@ describe('RelayController', () => {
       };
 
       await request(app.getHttpServer())
-        .post('/v1/relay')
+        .post('/api/v1/relay')
         .send(body)
         .expect(201);
 
@@ -84,7 +85,7 @@ describe('RelayController', () => {
       };
 
       await request(app.getHttpServer())
-        .post('/v1/relay')
+        .post('/api/v1/relay')
         .send(body)
         .expect(400);
 
@@ -105,7 +106,7 @@ describe('RelayController', () => {
       };
 
       await request(app.getHttpServer())
-        .post('/v1/relay')
+        .post('/api/v1/relay')
         .send(body)
         .expect(400);
 
@@ -126,7 +127,7 @@ describe('RelayController', () => {
       };
 
       await request(app.getHttpServer())
-        .post('/v1/relay')
+        .post('/api/v1/relay')
         .send(body)
         .expect(400);
 
@@ -148,7 +149,7 @@ describe('RelayController', () => {
       };
 
       await request(app.getHttpServer())
-        .post('/v1/relay')
+        .post('/api/v1/relay')
         .send(body)
         .expect(400);
 
@@ -156,7 +157,7 @@ describe('RelayController', () => {
     });
   });
 
-  describe('/v1/relay/:chainId/:address (GET)', () => {
+  describe('/api/v1/relay/:chainId/:address (GET)', () => {
     it('should return a 200 when the body is valid', async () => {
       const relayServiceSpy = jest.spyOn(relayLimitService, 'getRelayLimit');
 

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -165,7 +165,7 @@ describe('RelayController', () => {
       const address = faker.finance.ethereumAddress();
 
       await request(app.getHttpServer())
-        .get(`/v1/relay/${chainId}/${address}`)
+        .get(`/api/v1/relay/${chainId}/${address}`)
         .expect(200);
 
       expect(relayServiceSpy).toHaveBeenCalledTimes(1);
@@ -178,7 +178,7 @@ describe('RelayController', () => {
       const address = faker.finance.ethereumAddress();
 
       await request(app.getHttpServer())
-        .get(`/v1/relay/${chainId}/${address}`)
+        .get(`/api/v1/relay/${chainId}/${address}`)
         .expect(400);
 
       expect(relayServiceSpy).not.toHaveBeenCalled();
@@ -191,7 +191,7 @@ describe('RelayController', () => {
       const address = '0x123';
 
       await request(app.getHttpServer())
-        .get(`/v1/relay/${chainId}/${address}`)
+        .get(`/api/v1/relay/${chainId}/${address}`)
         .expect(400);
 
       expect(relayServiceSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
This adds the `/api` prefix to all routes, e.g. `/api/v1/relay`.