### PR TITLE
fix: allow all origins in cors header

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.enableVersioning();
 
+  // TODO: Define cors headers which we want to allow.
   app.enableCors({
     origin: '*',
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,10 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.enableVersioning();
 
+  app.enableCors({
+    origin: '*',
+  });
+
   const configService = app.get(ConfigService);
   const port = configService.get('applicationPort');
 


### PR DESCRIPTION
Requests from `localhost:3000` would fail otherwise. 

We have to consider later which URLs to allow in the cors header. 