### PR TITLE
fix: pass gas limit to gelato as string

### DIFF
--- a/src/routes/relay/relay.service.spec.ts
+++ b/src/routes/relay/relay.service.spec.ts
@@ -16,7 +16,7 @@ describe('getRelayGasLimit', () => {
     const GAS_LIMIT_BUFFER = 150_000;
 
     expect(_getRelayGasLimit('100000')).toBe(
-      BigInt(100000) + BigInt(GAS_LIMIT_BUFFER),
+      (BigInt(100000) + BigInt(GAS_LIMIT_BUFFER)).toString(),
     );
   });
 });

--- a/src/routes/relay/relay.service.ts
+++ b/src/routes/relay/relay.service.ts
@@ -11,14 +11,14 @@ import { RelayLimitService } from './services/relay-limit.service';
  * buffer reduces your chance of the task cancelling before it is executed on-chain.
  * @see https://docs.gelato.network/developer-services/relay/quick-start/optional-parameters
  */
-export const _getRelayGasLimit = (gasLimit?: string): bigint | undefined => {
+export const _getRelayGasLimit = (gasLimit?: string): string | undefined => {
   const GAS_LIMIT_BUFFER = 150_000;
 
   if (!gasLimit) {
     return undefined;
   }
 
-  return BigInt(gasLimit) + BigInt(GAS_LIMIT_BUFFER);
+  return (BigInt(gasLimit) + BigInt(GAS_LIMIT_BUFFER)).toString();
 };
 
 @Injectable()


### PR DESCRIPTION
Gelato can not handle bigints as gasLimit and fails the relaying.

Therefore we have to convert BigInt to string.