### PR TITLE
Set the relay path in the controller

### DIFF
--- a/src/routes/relay/relay.controller.ts
+++ b/src/routes/relay/relay.controller.ts
@@ -11,6 +11,7 @@ import { RelayLimitService } from './services/relay-limit.service';
 
 @Controller({
   version: '1',
+  path: 'relay',
 })
 export class RelayController {
   constructor(
@@ -18,7 +19,7 @@ export class RelayController {
     private readonly relayLimitService: RelayLimitService,
   ) {}
 
-  @Post('relay')
+  @Post('')
   sponsoredCall(
     @Body(new ZodValidationPipe(SponsoredCallSchema))
     sponsoredCallDto: SponsoredCallDto,
@@ -26,7 +27,7 @@ export class RelayController {
     return this.relayService.sponsoredCall(sponsoredCallDto);
   }
 
-  @Get('relay/:chainId/:address')
+  @Get(':chainId/:address')
   getRelayLimit(
     @Param('chainId', new ZodValidationPipe(ChainIdSchema))
     chainId: string,


### PR DESCRIPTION
- All the routes in relay.controller.ts are under the `relay` path
- By setting the path in the controller itself we can safely remove it from each route under this controller and see the root of the controller as the "relay" resource.