### PR TITLE
fix: validate env vars

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -1,19 +1,40 @@
+import { z } from 'zod';
+
 import { SupportedChainId } from './constants';
 
-export default () => ({
-  about: {
-    name: 'safe-gelato-relay-service',
-  },
-  applicationPort: process.env.APPLICATION_PORT || '3000',
-  relay: {
-    ttl: process.env.THROTTLE_TTL || 60 * 60, // 1 hour
-    limit: process.env.THROTTLE_LIMIT || 5,
-  },
-  gelato: {
-    apiKey: {
-      [SupportedChainId.GOERLI]: process.env.GELATO_GOERLI_API_KEY,
-      [SupportedChainId.GNOSIS_CHAIN]: process.env.GELATO_GNOSIS_CHAIN_API_KEY,
-    },
-  },
-  gatewayUrl: process.env.GATEWAY_URL || 'https://safe-client.safe.global',
+const ConfigurationSchema = z.object({
+  applicationPort: z.string(),
+  relay: z.object({
+    ttl: z.number(),
+    limit: z.number(),
+  }),
+  gelato: z.object({
+    apiKey: z.object({
+      [SupportedChainId.GOERLI]: z.string(),
+      [SupportedChainId.GNOSIS_CHAIN]: z.string(),
+    }),
+  }),
+  gatewayUrl: z.string(),
 });
+
+export default () => {
+  return ConfigurationSchema.parse({
+    applicationPort: process.env.APPLICATION_PORT || '3000',
+    relay: {
+      ttl: process.env.THROTTLE_TTL
+        ? Number(process.env.THROTTLE_TTL)
+        : 60 * 60, // 1 hour
+      limit: process.env.THROTTLE_LIMIT
+        ? Number(process.env.THROTTLE_LIMIT)
+        : 5,
+    },
+    gelato: {
+      apiKey: {
+        [SupportedChainId.GOERLI]: process.env.GELATO_GOERLI_API_KEY,
+        [SupportedChainId.GNOSIS_CHAIN]:
+          process.env.GELATO_GNOSIS_CHAIN_API_KEY,
+      },
+    },
+    gatewayUrl: process.env.GATEWAY_URL || 'https://safe-client.safe.global',
+  });
+};

--- a/src/datasources/sponsor/gelato.sponsor.service.ts
+++ b/src/datasources/sponsor/gelato.sponsor.service.ts
@@ -32,7 +32,9 @@ export class GelatoSponsorService implements ISponsorService {
   ): Promise<RelayResponse> {
     const { chainId, data, to } = sponsoredCallDto;
 
-    const apiKey = this.configService.getOrThrow(`gelato.apiKey.${chainId}`);
+    const apiKey = this.configService.getOrThrow<string>(
+      `gelato.apiKey.${chainId}`,
+    );
 
     const gasLimit = sponsoredCallDto.gasLimit
       ? this.getRelayGasLimit(sponsoredCallDto.gasLimit).toString()


### PR DESCRIPTION
This validates the env vars, throwing if they are not defined when starting the service.