### PR TITLE
Disable autodeploy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
           cache-to: type=inline
 
   autodeploy:
+    # Re-enable this job when deployment environment is ready
+    if: ${{ false }}
     runs-on: ubuntu-latest
     needs: [ docker-publish ]
     steps:


### PR DESCRIPTION
- There is no environment yet deployed for this service so this actions is always going to fail until then