### PR TITLE
Add `/relay/health` endpoint

### DIFF
--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -522,7 +522,9 @@ describe('RelayController', () => {
 
   describe('/v1/relay/health (GET)', () => {
     it('should return a 200 response', async () => {
-      await request(app.getHttpServer()).get(`/v1/relay/health`).expect(200);
+      await request(app.getHttpServer())
+        .get(`/v1/relay/health`)
+        .expect(200, {});
     });
   });
 });

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -519,4 +519,10 @@ describe('RelayController', () => {
       });
     });
   });
+
+  describe('/v1/relay/health (GET)', () => {
+    it('should return a 200 response', async () => {
+      await request(app.getHttpServer()).get(`/v1/relay/health`).expect(200);
+    });
+  });
 });

--- a/src/routes/relay/relay.controller.ts
+++ b/src/routes/relay/relay.controller.ts
@@ -39,4 +39,9 @@ export class RelayController {
   } {
     return this.relayLimitService.getRelayLimit(chainId, address);
   }
+
+  @Get('health')
+  getHealth() {
+    return;
+  }
 }


### PR DESCRIPTION
## What it solves

Adds a new endpoint `/relay/health` that returns an empty 200 response

## Screenshot

<img width="988" alt="Screenshot 2023-03-13 at 16 23 10" src="https://user-images.githubusercontent.com/5880855/224747770-e22ec6e3-5db7-49ca-8a7a-c78bc5ab0c5c.png">
