### PR TITLE
Revert "Disable autodeploy job (#26)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,6 @@ jobs:
           cache-to: type=inline
 
   autodeploy:
-    # Re-enable this job when deployment environment is ready
-    if: ${{ false }}
     runs-on: ubuntu-latest
     needs: [ docker-publish ]
     steps:


### PR DESCRIPTION
This reverts commit 2ee99326ef7790d16ec47c777478d71d27f63b78.

We have a deployment environment ready so we can trigger the autodeploy job when a new commit is pushed to `main`