### PR TITLE
Add support for Coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+  pull_request:
 
 jobs:
   prettier:
@@ -36,7 +37,9 @@ jobs:
           cache: 'yarn'
       - run: yarn install --immutable
       - run: yarn run build
-      - run: yarn run test
+      - run: yarn run test:cov
+      - name: Upload Coverage
+        uses: coverallsapp/github-action@v1
 
   docker-publish:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main')

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Safe Gelato Relay Service
 
+[![Coverage Status](https://coveralls.io/repos/github/5afe/safe-gelato-relay-service/badge.svg?branch=main)](https://coveralls.io/github/5afe/safe-gelato-relay-service?branch=main)
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
- Uploads coverage to Coveralls
- Adds `pull_request` trigger as this is required in order for the integration to publish coverage reports in the Pull Request itself
- Adds coverage badge to `README.md`