### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ but it is currently not covered.
 
 ## Docker
 
-Development images are currently being published to Docker Hub. 
-You can find them here: https://hub.docker.com/r/safeglobal/safe-gelato-relay-service.
+Development images are currently being published to [Docker Hub](https://hub.docker.com/r/safeglobal/safe-gelato-relay-service).
 
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ yarn run start:prod
 
 ## Test
 
-If you want to execute the tests for the service you can execute the following:
+If you want to execute the tests for the service, you can execute the following:
 
 ```bash
 yarn run test

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/5afe/safe-gelato-relay-service/badge.svg?branch=main)](https://coveralls.io/github/5afe/safe-gelato-relay-service?branch=main)
 
-**⚠️ Warning: This service is currently going active development. Functionality might change considerably.**
+**⚠️ Warning: This service is currently undergoing active development. Functionality might change considerably.**
 
 The Safe Gelato Relay Service is a web service which allows relaying transactions via the 
 [Gelato Relay Service](https://docs.gelato.network/developer-services/relay).

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Currently two chains are supported: Goerli (chainId=5) and Gnosis Chain (chainId
 # To configure Goerli
 export GELATO_GOERLI_API_KEY=<GOERLI_GELATO_API_KEY>
 
-# To configure Gnosis Chains
+# To configure Gnosis Chain
 export GELATO_GNOSIS_CHAIN_API_KEY=<GNOSIS_GELATO_API_KEY>
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ corepack enable && yarn install
 ## Running the service
 
 Before running the service you need to set up a Gelato API Key ([instructions](https://docs.gelato.network/developer-services/relay/payment-and-fees/1balance#production)).
-This can be done via an environment variable in the local environment where you are executing the service:
+This can be added via an environment variable in the local environment where you are executing the service:
 
 Currently two chains are supported: Goerli (chainId=5) and Gnosis Chain (chainId=100).
 ```bash

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ corepack enable && yarn install
 
 ## Running the service
 
-Before running the service you need to set up the Gelato API Key ([instructions](https://docs.gelato.network/developer-services/relay/payment-and-fees/1balance#production)).
+Before running the service you need to set up a Gelato API Key ([instructions](https://docs.gelato.network/developer-services/relay/payment-and-fees/1balance#production)).
 This can be done via an environment variable in the local environment where you are executing the service:
 
 Currently two chains are supported: Goerli (chainId=5) and Gnosis Chain (chainId=100).

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ By default, the coverage results will be under `<PROJ_FOLDER>/coverage/`.
 
 ## Linter and Style Guide
 
-We use [ESLint](https://eslint.org/) as a Linter and [Prettier](https://prettier.io/) as a code formatter.
+We use [ESLint](https://eslint.org/) as a linter and [Prettier](https://prettier.io/) as a code formatter.
 You can run `yarn run lint` to execute ESLint and `yarn run format` to execute Prettier.
 
 These checks are automatically executed using Git hooks (automatically installed with the project).

--- a/README.md
+++ b/README.md
@@ -2,44 +2,91 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/5afe/safe-gelato-relay-service/badge.svg?branch=main)](https://coveralls.io/github/5afe/safe-gelato-relay-service?branch=main)
 
+**⚠️ Warning: This service is currently going active development. Functionality might change considerably.**
+
+The Safe Gelato Relay Service is a web service which allows relaying transactions via the 
+[Gelato Relay Service](https://docs.gelato.network/developer-services/relay).
+
+This allows for an entity to sponsor on-chain transactions on behalf of the user, allowing them
+to submit Safe transactions without the need to have a wallet with funds. Fee collection can happen via other means
+but it is currently not covered.
+
+## Docker
+
+Development images are currently being published to Docker Hub. 
+You can find them here: https://hub.docker.com/r/safeglobal/safe-gelato-relay-service.
+
+
+## Requirements
+
+- Node 18 (LTS) – https://nodejs.org/en/
+- Gelato's 1Balance API key – Follow instructions at: https://docs.gelato.network/developer-services/relay/payment-and-fees/1balance#production 
+
 ## Installation
 
 ```bash
 corepack enable && yarn install
 ```
 
-## Running the app
+## Running the service
+
+Before running the service you need to set up the Gelato API Key ([instructions](https://docs.gelato.network/developer-services/relay/payment-and-fees/1balance#production)).
+This can be done via an environment variable in the local environment where you are executing the service:
+
+Currently two chains are supported: Goerli (chainId=5) and Gnosis Chain (chainId=100).
+```bash
+# To configure Goerli
+export GELATO_GOERLI_API_KEY=<GOERLI_GELATO_API_KEY>
+
+# To configure Gnosis Chains
+export GELATO_GNOSIS_CHAIN_API_KEY=<GNOSIS_GELATO_API_KEY>
+```
+
+Both chains can be configured simultaneously.
+
+---
+
+With the API keys configured, to run the service locally:
 
 ```bash
-# development
-$ yarn run start
+yarn run start
+```
 
-# watch mode
-$ yarn run start:dev
+The service will then be listening for requests under `$APPLICATION_PORT`. If `$APPLICATION_PORT` was not set, the default
+port is `3000`.
 
-# production mode
-$ yarn run start:prod
+Other execution modes are available for local development:
+
+```bash
+# Run in watch mode (live-reload)
+yarn run start:dev
+
+# Run in debug mode (if you want to attach a debugger)
+yarn run start:debug
+
+# Launch the service without the NestJS CLI (production target)
+yarn run start:prod
 ```
 
 ## Test
 
-```bash
-# unit tests
-$ yarn run test
-
-# e2e tests
-$ yarn run test:e2e
-
-# test coverage
-$ yarn run test:cov
-```
-
-## Running service locally
+If you want to execute the tests for the service you can execute the following:
 
 ```bash
-# start service
-docker-compose up -d
-
-# stop service
-docker-compose stop
+yarn run test
 ```
+
+Additionally, if you want the test coverage to be generated you can execute the following:
+
+```bash
+yarn run test:cov
+```
+
+By default, the coverage results will be under `<PROJ_FOLDER>/coverage/`
+
+## Linter and Style Guide
+
+We use [ESLint](https://eslint.org/) as a Linter and [Prettier](https://prettier.io/) as a code formatter.
+You can run `yarn run lint` to execute ESLint and `yarn run format` to execute Prettier.
+
+These checks are automatically executed using Git hooks (automatically installed with the project).

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you want to execute the tests for the service, you can execute the following:
 yarn run test
 ```
 
-Additionally, if you want the test coverage to be generated you can execute the following:
+Additionally, if you want the test coverage to be generated, you can execute the following:
 
 ```bash
 yarn run test:cov

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Development images are currently being published to [Docker Hub](https://hub.doc
 ## Requirements
 
 - Node 18 (LTS) – https://nodejs.org/en/
-- Gelato's 1Balance API key – Follow instructions at: https://docs.gelato.network/developer-services/relay/payment-and-fees/1balance#production 
+- Gelato's 1Balance API key – https://docs.gelato.network/developer-services/relay/payment-and-fees/1balance#production 
 
 ## Installation
 
@@ -29,7 +29,7 @@ corepack enable && yarn install
 
 ## Running the service
 
-Before running the service you need to set up a Gelato API Key ([instructions](https://docs.gelato.network/developer-services/relay/payment-and-fees/1balance#production)).
+Before running the service you need to set up a Gelato API Key – https://docs.gelato.network/developer-services/relay/payment-and-fees/1balance#production.
 This can be added via an environment variable in the local environment where you are executing the service:
 
 Currently two chains are supported: Goerli (chainId=5) and Gnosis Chain (chainId=100).

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Additionally, if you want the test coverage to be generated, you can execute the
 yarn run test:cov
 ```
 
-By default, the coverage results will be under `<PROJ_FOLDER>/coverage/`
+By default, the coverage results will be under `<PROJ_FOLDER>/coverage/`.
 
 ## Linter and Style Guide
 


### PR DESCRIPTION
- Adds description about the service
- Adds Docker section with links to Docker Hub
- Adds a section about requirements to run the service locally
- Adds a more detailed instructions on running the service and the configuration required
- Adds a more detailed description on how to run the service in different modes
- Adds a section about the Linter and Code Formatter being used

Markdown rendering can be viewed at: https://github.com/5afe/safe-gelato-relay-service/blob/update-readme/README.md