### PR TITLE
fix: remove `cause` from `ZodValidationPipe`

### DIFF
--- a/src/pipes/zod/zod-validation.pipe.ts
+++ b/src/pipes/zod/zod-validation.pipe.ts
@@ -17,7 +17,6 @@ export class ZodValidationPipe implements PipeTransform {
       throw new HttpException(
         'Validation failed',
         HttpStatus.UNPROCESSABLE_ENTITY,
-        { cause: result.error },
       );
     }
 


### PR DESCRIPTION
This removes the `cause` from our generic `ZodValidationPipe` to prevent the leaking of any internal data.